### PR TITLE
added docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 
 Simple webservice that takes a Rumble.com channel URL and returns an RSS feed containing a list of videos from the channel.
 
-## Example Usage
+## Example docker-compose Usage
+
+```
+docker-compose up -d
+
+curl localhost:8080?link=https://rumble.com/mychannel
+```
+
+## Example Docker Usage
 
 ```
 docker pull ghcr.io/porjo/rumblerss:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.8"
+
+services:
+  app:
+    image: ghcr.io/porjo/rumblerss:latest
+    container_name: rumblerss
+    restart: unless-stopped
+# to build locally uncomment bellow and comment out the above image: ghcr.io link
+#    image: rumblerss
+#    build:
+#      context: .
+    ports:
+      - 8080:8080


### PR DESCRIPTION
The docker-compose now fetches directly from ghcr.io/porjo/rumblerss:latest

Ability to build locally if needed.

Updated README for docker-compose usage